### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10
 
-RUN apt-get update && apt-get install -y python3 python3-dev python3-pip unixodbc-dev;
+RUN apt-get update && apt-get install -y python3 python3-dev python3-pip unixodbc-dev python3-cffi;
 # Install OpenJDK-8
 RUN apt-get update && \
     apt-get install -y openjdk-11-jdk && \
@@ -12,6 +12,10 @@ RUN apt-get update && \
     apt-get install ca-certificates-java && \
     apt-get clean && \
     update-ca-certificates -f;
+
+RUN apt-get update && \
+    apt-get install -y libffi-dev && \
+    apt-get clean;
 
 # Setup JAVA_HOME -- useful for docker commandline
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/


### PR DESCRIPTION
fix for missing "cffi.h"  header file during the wheel build of "cryptography" that is a dependency of jwt from the requirements.txt file.

I tried to add the python3-libffi it to the requirements.txt file, but this didn't fix the issue for me.  I  had to install the Debian package "python3-cffi" and "libffi-dev" for the Docker container to sucessfully build.